### PR TITLE
Add check for .tmp existence

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -87,9 +87,16 @@ runs:
           echo "::set-output name=compare_state::compatible"
         fi
       shell: bash
-    - name: "Post: Change folder own group"
+    - name: Check file existence
+      id: check_files
+      uses: andstor/file-existence-action@v1
+      with:
+        files: ".tmp"
+    - name: "Change folder own group"
+      if: steps.check_files.outputs.files_exists == 'true'
       run: sudo chown -R $USER:$USER .tmp
       shell: bash
-    - name: "Post: Remove .tmp directory"
+    - name: "Remove .tmp directory"
+      if: steps.check_files.outputs.files_exists == 'true'
       run: rm -fr .tmp
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -87,16 +87,16 @@ runs:
           echo "::set-output name=compare_state::compatible"
         fi
       shell: bash
-    - name: Check file existence
+    - name: "Check file existence"
       id: check_files
       uses: andstor/file-existence-action@v1
       with:
         files: ".tmp"
-    - name: "Change folder own group"
+    - name: "Post: Change folder own group"
       if: steps.check_files.outputs.files_exists == 'true'
       run: sudo chown -R $USER:$USER .tmp
       shell: bash
-    - name: "Remove .tmp directory"
+    - name: "Post: Remove .tmp directory"
       if: steps.check_files.outputs.files_exists == 'true'
       run: rm -fr .tmp
       shell: bash


### PR DESCRIPTION
THIS PROJECT IS IN MAINTENANCE MODE. We accept pull-requests for Bug Fixes **ONLY**. NO NEW FEATURES ACCEPTED!

<!--- Provide a general summary of your changes in the Title above -->
Add check for `.tmp` folder existence

## Description
(copy summary)

## Related Issue
[Action fails if all output formats are specified in a non .tmp folder](https://github.com/swimmwatch/openapi-diff-action/issues/1)

## Motivation and Context
It fixes the bug from #1.

## How Has This Been Tested (if appropriate)?
Created test repository with issue testcase.

## Screenshots (if appropriate):
(none)